### PR TITLE
Add error callback function, catch thrown errors

### DIFF
--- a/example/input_event_example.dart
+++ b/example/input_event_example.dart
@@ -10,8 +10,11 @@ void main() {
     while (true) {}
   });
 
-  // This will receive all events from the device file
-  final events = InputEventController(deviceFile);
+  // This will receive all events from the device file and print errors to console
+  final events = InputEventController(deviceFile, onError: (err) {
+    print("Error from input_event: $err");
+  });
+
   events.eventStream.stream.listen((data) {
     print(data);
   });


### PR DESCRIPTION
* Adds a required error handler function to the class.
* Adds a new error that can be thrown if an input event does not match the expected byte length, this can be caught by application code, allowing a restart or other application specific error handling.